### PR TITLE
Using Read and Write open parameter instead of Write only

### DIFF
--- a/runtime/MemTraceSys.cpp
+++ b/runtime/MemTraceSys.cpp
@@ -87,7 +87,7 @@ void MemTrace::closesocket(SOCKET s)
 
 MemTrace::FileHandle MemTrace::FileOpenForReadWrite(const char* fn)
 {
-  return open(fn, O_WRONLY|O_CREAT, 0666);
+  return open(fn, O_RDWR|O_CREAT, 0666);
 }
 
 void MemTrace::FileWrite(FileHandle fh, const void* data, size_t size)


### PR DESCRIPTION
When the user switch to the socket connection, MemTrace needs to read back the content of the file, the file needs to be opened with the O_RDWR  in order to ensure the right operation order:

O_RDONLY
Open for reading only.
O_WRONLY
Open for writing only.
O_RDWR
Open for reading and writing. The result is undefined if this flag is applied to a FIFO.