### PR TITLE
Improve performance during a MemTrace capture

### DIFF
--- a/runtime/MemTraceSys.cpp
+++ b/runtime/MemTraceSys.cpp
@@ -87,7 +87,7 @@ void MemTrace::closesocket(SOCKET s)
 
 MemTrace::FileHandle MemTrace::FileOpenForReadWrite(const char* fn)
 {
-  return open(fn, O_WRONLY|O_CREAT, 0666);
+  return open(fn, O_RDWR|O_CREAT, 0666);
 }
 
 void MemTrace::FileWrite(FileHandle fh, const void* data, size_t size)

--- a/tool/MemTrace/TraceTranscoder.cs
+++ b/tool/MemTrace/TraceTranscoder.cs
@@ -35,6 +35,7 @@ namespace MemTrace
     public const uint StreamMagic = 0xbfaf0003;
 
     public TraceMeta MetaData { get; private set; }
+    public HashSet<ulong> SymbolsHashSet { get; internal set; } = new HashSet<ulong>();
 
     private const uint BufferSize = 128 * 1024;
     private const uint RingMask = BufferSize - 1;
@@ -529,8 +530,12 @@ namespace MemTrace
           return false;
         }
 
-        if (!MetaData.Symbols.Contains(frames[i]))
+        if (!SymbolsHashSet.Contains(frames[i]))
+        {
           MetaData.Symbols.Add(frames[i]);
+          SymbolsHashSet.Add(frames[i]);
+        }
+        
       }
 
       ++m_SeenStackRollback;


### PR DESCRIPTION
Adding an HashSet in the tools code to avoid linear search time (https://github.com/deplinenoise/ig-memtrace/issues/12)